### PR TITLE
[update] migrate terminal emulator from Alacritty to WezTerm

### DIFF
--- a/config/zellij/config.kdl
+++ b/config/zellij/config.kdl
@@ -324,7 +324,7 @@ pane_frames false
 //   - detach (Default)
 //   - quit
 // 
-// on_force_close "quit"
+on_force_close "quit"
  
 // Configure the scroll back buffer size
 // This is the number of lines zellij stores for each pane in the scroll back

--- a/home/.wezterm.lua
+++ b/home/.wezterm.lua
@@ -1,0 +1,21 @@
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+
+config.color_scheme = "iceberg-dark"
+config.font = wezterm.font("CodeM Nerd Font")
+config.font_size = 14
+config.cell_width = 0.81
+config.ime_preedit_rendering = "System"
+config.enable_tab_bar = false
+config.default_prog = { "/bin/zsh", "-l", "-c", "zellij attach --index 0 --create" }
+config.window_padding = {
+  left = 0,
+  right = 0,
+  top = 0,
+  bottom = 0,
+}
+config.window_close_confirmation = "NeverPrompt"
+config.initial_cols = 160
+config.initial_rows = 48
+
+return config


### PR DESCRIPTION
## Summary
- Add WezTerm configuration with iceberg-dark theme, CodeM Nerd Font, and zellij auto-attach
- Enable `on_force_close "quit"` in zellij config

## Test plan
- Verify WezTerm launches with correct theme, font, and zellij session
- Verify zellij force close behavior works as expected

## Breaking changes
None