### PR TITLE
[update] enable zellij session serialization and detach on force close

### DIFF
--- a/config/zellij/config.kdl
+++ b/config/zellij/config.kdl
@@ -324,7 +324,7 @@ pane_frames false
 //   - detach (Default)
 //   - quit
 // 
-on_force_close "quit"
+on_force_close "detach"
  
 // Configure the scroll back buffer size
 // This is the number of lines zellij stores for each pane in the scroll back
@@ -397,7 +397,7 @@ on_force_close "quit"
 //   - true
 //   - false (default)
 // 
-// serialize_pane_viewport false
+serialize_pane_viewport true
  
 // Scrollback lines to serialize along with the pane viewport when serializing sessions, 0
 // defaults to the scrollback size. If this number is higher than the scrollback size, it will
@@ -414,7 +414,7 @@ on_force_close "quit"
  
 // How often in seconds sessions are serialized
 // 
-// serialization_interval 10000
+serialization_interval 60
  
 // Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
 // metadata info on this session)


### PR DESCRIPTION
## Summary
- Change `on_force_close` from `quit` to `detach` so forcibly closing the terminal leaves the session alive for reattachment instead of destroying it.
- Enable `serialize_pane_viewport` so pane scrollback/viewport is preserved across resurrected sessions.
- Set `serialization_interval` to 60 seconds (down from the 10000-second default) so session state is persisted frequently enough to recover after an unexpected disconnect.

## Test plan
- Open a zellij session, run a few commands, and forcibly close the terminal emulator (or kill the process). Re-attach with `zellij attach` and confirm the session is still listed and reattaches with prior pane contents.
- Wait at least 60 seconds after producing output, then kill the session host; reattach and confirm recent output is restored.

## Breaking changes
None. The change only affects local zellij behavior; existing sessions and configs continue to work.