### PR TITLE
[add] manage ssh secrets with rbw

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Check bin/arch_install.sh
         run: shellcheck bin/arch_install.sh
 
+      - name: Check bin/secrets.sh
+        run: shellcheck -e SC1091 bin/secrets.sh
+
       - name: Check home/.zshrc
         run: shellcheck home/.zshrc --exclude=SC2148,SC1090,SC1091,SC2015,SC2034,SC2086

--- a/Brewfile
+++ b/Brewfile
@@ -69,10 +69,14 @@ brew "opensc"
 brew "platformio"
 # Object-relational database system
 brew "postgresql@18", link: true
+# Passphrase entry dialog for GnuPG (used by rbw)
+brew "pinentry-mac"
 # Modern replacement for ps written in Rust
 brew "procs"
 # Search tool like grep and The Silver Searcher
 brew "ripgrep"
+# Unofficial Bitwarden CLI with a built-in SSH agent
+brew "rbw"
 # Python library for creating static, animated, and interactive visualizations
 brew "python-matplotlib"
 # Interpreted, interactive, object-oriented programming language

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 DOT_DIRECTORY = $(HOME)/dotfiles
 INSTALL_SH    = $(DOT_DIRECTORY)/bin/install.sh
+SECRETS_SH    = $(DOT_DIRECTORY)/bin/secrets.sh
 
 .DEFAULT_GOAL := help
-.PHONY: deploy init backup update install help
+.PHONY: deploy init backup update install secrets secrets-push secrets-setup help
 
 deploy: ## Create symlink to home directory
 	@bash $(INSTALL_SH) --deploy
@@ -18,6 +19,15 @@ update: ## Fetch changes for this repo
 
 install: ## Install packages for current platform
 	@bash $(INSTALL_SH) --install
+
+secrets-setup: ## Configure rbw for the Bitwarden vault
+	@bash $(SECRETS_SH) setup
+
+secrets: ## Write ~/.ssh/config from the Bitwarden vault
+	@bash $(SECRETS_SH) pull
+
+secrets-push: ## Store the current ~/.ssh/config in the Bitwarden vault
+	@bash $(SECRETS_SH) push
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) \

--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ Dotfiles
 ``` shell
 $ bash -c "$(curl -L dot.smngs.io/install.sh)"
 ```
+
+## Secrets
+
+SSH keys and `~/.ssh/config` live in Bitwarden, not in this repository.
+See [docs/secrets.md](docs/secrets.md).

--- a/bin/secrets.sh
+++ b/bin/secrets.sh
@@ -7,13 +7,18 @@
 set -euo pipefail
 
 SSH_CONFIG_ITEM="${SSH_CONFIG_ITEM:-dotfiles-ssh-config}"
+SSH_KEY_ITEM="${SSH_KEY_ITEM:-SSH}"
 SSH_CONFIG_PATH="${HOME}/.ssh/config"
 LOCK_TIMEOUT="${RBW_LOCK_TIMEOUT:-300}"
+
+# Hosts that authenticate by public key but have no authorized_keys file
+SKIP_HOSTS_RE='^(github\.com|gitlab\.com|bitbucket\.org|ssh\.dev\.azure\.com)$'
 
 # shell-logger.sh is deliberately not used here: its err() returns 100, which
 # would abort the script under set -e before the message is acted on.
 info ()   { printf '\033[0;32m[INFO]\033[0m %s\n' "$*"; }
 notice () { printf '\033[0;34m[NOTICE]\033[0m %s\n' "$*"; }
+warn ()   { printf '\033[0;33m[WARNING]\033[0m %s\n' "$*" >&2; }
 err ()    { printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2; }
 
 require_rbw () {
@@ -31,12 +36,17 @@ require_configured () {
   fi
 }
 
+# Terminal pinentry on purpose: the agent is often driven over ssh, where a
+# GUI prompt cannot be answered.
 default_pinentry () {
-  case "$(uname -s)" in
-    Darwin*) command -v pinentry-mac >/dev/null 2>&1 && { echo pinentry-mac; return; } ;;
-  esac
-  command -v pinentry >/dev/null 2>&1 && { echo pinentry; return; }
-  echo pinentry-curses
+  local p
+  for p in pinentry-curses pinentry-tty pinentry; do
+    if command -v "${p}" >/dev/null 2>&1; then
+      echo "${p}"
+      return
+    fi
+  done
+  echo pinentry
 }
 
 # rbw uses $XDG_RUNTIME_DIR when present and falls back to a temp dir keyed by
@@ -85,7 +95,9 @@ pull () {
   # shellcheck disable=SC2064
   trap "rm -f '${tmp}'" EXIT
 
-  if ! rbw get "${SSH_CONFIG_ITEM}" --field notes > "${tmp}"; then
+  # The command substitution drops the trailing newline rbw appends, so the
+  # file does not grow a blank line on every round trip.
+  if ! printf '%s\n' "$(rbw get "${SSH_CONFIG_ITEM}" --field notes)" > "${tmp}"; then
     err "Could not read '${SSH_CONFIG_ITEM}' from the vault."
     err "Store the config first with: $(basename "$0") push"
     exit 1
@@ -101,36 +113,200 @@ pull () {
   info "Wrote ${SSH_CONFIG_PATH} from '${SSH_CONFIG_ITEM}'."
 }
 
+# rbw cannot write items non-interactively: `rbw add` waits on $EDITOR and
+# never returns without a tty. Writing therefore goes through the official
+# bw CLI, which accepts JSON. Reading stays on rbw.
+ensure_bw_session () {
+  if ! command -v bw >/dev/null 2>&1; then
+    err "bw is not installed. Run 'make install' first."
+    exit 1
+  fi
+  if [ -n "${BW_SESSION:-}" ] && bw list items --session "${BW_SESSION}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # bw keeps its own credentials, separate from rbw's: the vault can be
+  # unlocked in rbw while bw is not even logged in.
+  local bw_status
+  bw_status="$(bw status 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>/dev/null)"
+  if [ "${bw_status}" = "unauthenticated" ]; then
+    err "bw is not logged in (rbw and bw hold separate credentials)."
+    err "Run once, from a normal terminal:  bw login ${BW_EMAIL:-<email>}"
+    exit 1
+  fi
+  # `bw unlock --raw` writes its prompt to stdout, so it breaks under command
+  # substitution (ERR_USE_AFTER_CLOSE). Read the password here and hand it
+  # over through the environment instead. /dev/tty is not usable in every
+  # host terminal, so stdin is used directly.
+  local pw
+  printf 'Master password: '
+  if ! IFS= read -rs pw; then
+    printf '\n'
+    err "Could not read the master password from stdin."
+    exit 1
+  fi
+  printf '\n'
+
+  BW_SESSION="$(BW_PASSWORD="${pw}" bw unlock --passwordenv BW_PASSWORD --raw)" || {
+    err "Failed to unlock the vault."
+    exit 1
+  }
+  unset pw
+  export BW_SESSION
+}
+
 push () {
-  require_configured
+  require_rbw
 
   if [ ! -f "${SSH_CONFIG_PATH}" ]; then
     err "${SSH_CONFIG_PATH} does not exist."
     exit 1
   fi
 
-  # rbw add/edit opens $EDITOR on a temp file and treats the first line as the
-  # password, so prepend a blank line to keep the config intact in the notes.
-  local editor tmp
-  editor="$(mktemp)"
-  tmp="$(mktemp)"
-  # shellcheck disable=SC2064
-  trap "rm -f '${editor}' '${tmp}'" EXIT
+  ensure_bw_session
+  bw sync --session "${BW_SESSION}" >/dev/null 2>&1 || true
 
-  { echo; cat "${SSH_CONFIG_PATH}"; } > "${tmp}"
+  local id
+  id="$(bw list items --search "${SSH_CONFIG_ITEM}" --session "${BW_SESSION}" 2>/dev/null \
+        | CFG_NAME="${SSH_CONFIG_ITEM}" python3 -c '
+import json, os, sys
+name = os.environ["CFG_NAME"]
+for item in json.load(sys.stdin):
+    if item.get("name") == name:
+        print(item["id"])
+        break
+')"
 
-  cat > "${editor}" <<EOF
-#!/bin/sh
-cat "${tmp}" > "\$1"
-EOF
-  chmod +x "${editor}"
-
-  if rbw get "${SSH_CONFIG_ITEM}" >/dev/null 2>&1; then
-    EDITOR="${editor}" VISUAL="${editor}" rbw edit "${SSH_CONFIG_ITEM}"
+  if [ -n "${id}" ]; then
+    bw get item "${id}" --session "${BW_SESSION}" \
+      | CFG_PATH="${SSH_CONFIG_PATH}" python3 -c '
+import json, os, sys
+item = json.load(sys.stdin)
+item["notes"] = open(os.environ["CFG_PATH"]).read()
+json.dump(item, sys.stdout)
+' | bw encode | bw edit item "${id}" --session "${BW_SESSION}" >/dev/null
     info "Updated '${SSH_CONFIG_ITEM}' in the vault."
   else
-    EDITOR="${editor}" VISUAL="${editor}" rbw add "${SSH_CONFIG_ITEM}"
+    bw get template item --session "${BW_SESSION}" \
+      | CFG_PATH="${SSH_CONFIG_PATH}" CFG_NAME="${SSH_CONFIG_ITEM}" python3 -c '
+import json, os, sys
+item = json.load(sys.stdin)
+item["type"] = 2                      # secure note
+item["secureNote"] = {"type": 0}
+item["name"] = os.environ["CFG_NAME"]
+item["notes"] = open(os.environ["CFG_PATH"]).read()
+item["login"] = None
+json.dump(item, sys.stdout)
+' | bw encode | bw create item --session "${BW_SESSION}" >/dev/null
     info "Created '${SSH_CONFIG_ITEM}' in the vault."
+  fi
+
+  rbw sync >/dev/null 2>&1 || true
+
+  # Reading back is the only proof the write landed; the previous
+  # implementation reported success while storing nothing.
+  local stored
+  stored="$(rbw get "${SSH_CONFIG_ITEM}" --field notes 2>/dev/null | wc -c | tr -d ' ')"
+  if [ "${stored}" -lt 10 ]; then
+    err "Verification failed: the vault item is empty."
+    exit 1
+  fi
+  info "Verified: ${stored} bytes readable from the vault."
+}
+
+# Host aliases from the ssh config, minus wildcard patterns
+config_hosts () {
+  [ -f "${SSH_CONFIG_PATH}" ] || return 0
+  awk '/^[Hh]ost[ \t]/ {
+         for (i = 2; i <= NF; i++)
+           if ($i !~ /[*?!]/) print $i
+       }' "${SSH_CONFIG_PATH}"
+}
+
+authorize_one () {
+  local host="$1" line="$2" result
+
+  if [[ "${host}" =~ ${SKIP_HOSTS_RE} ]]; then
+    warn "${host}: managed through its web UI, skipping"
+    return 0
+  fi
+
+  # The key travels over stdin so it is never interpolated into the remote
+  # shell command. Matching ignores the trailing comment, which differs
+  # between manual and scripted installs.
+  result="$(printf '%s\n' "${line}" | ssh -o ConnectTimeout=10 "${host}" '
+    key=$(cat)
+    body=$(printf "%s" "$key" | awk "{print \$1\" \"\$2}")
+    mkdir -p ~/.ssh && chmod 700 ~/.ssh
+    touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
+    if grep -qF "$body" ~/.ssh/authorized_keys; then
+      echo ALREADY
+    else
+      cp ~/.ssh/authorized_keys ~/.ssh/authorized_keys.bak
+      printf "%s\n" "$key" >> ~/.ssh/authorized_keys
+      echo ADDED
+    fi
+  ' 2>/dev/null)" || {
+    err "${host}: could not connect"
+    return 1
+  }
+
+  # Verify with a fresh connection; reusing a live ControlMaster would pass
+  # even when the key was never accepted.
+  if ssh -o BatchMode=yes -o ControlMaster=no -o ControlPath=none \
+         -o ConnectTimeout=10 "${host}" true 2>/dev/null; then
+    info "${host}: ${result:-?}, key authentication verified"
+  else
+    warn "${host}: ${result:-?}, but a fresh connection still failed"
+    return 1
+  fi
+}
+
+authorize () {
+  require_configured
+
+  local pubkey line hosts=() host failed=0 sock
+
+  # Both the install and the verification need the vault key, which only the
+  # rbw agent can offer.
+  if sock="$(ssh_agent_socket)"; then
+    export SSH_AUTH_SOCK="${sock}"
+  else
+    err "rbw's ssh agent is not running. Run 'rbw unlock' first."
+    exit 1
+  fi
+
+  pubkey="$(rbw get "${SSH_KEY_ITEM}" --field public_key)" || {
+    err "Could not read the public key from item '${SSH_KEY_ITEM}'."
+    exit 1
+  }
+  if [ -z "${pubkey}" ]; then
+    err "Item '${SSH_KEY_ITEM}' has no public key."
+    exit 1
+  fi
+  line="${pubkey} ${SSH_KEY_ITEM}@bitwarden"
+
+  if [ "$#" -gt 0 ]; then
+    hosts=("$@")
+  else
+    while IFS= read -r host; do
+      hosts+=("${host}")
+    done < <(config_hosts)
+  fi
+
+  if [ "${#hosts[@]}" -eq 0 ]; then
+    err "No hosts given and none found in ${SSH_CONFIG_PATH}."
+    exit 1
+  fi
+
+  info "Authorizing '${SSH_KEY_ITEM}' on ${#hosts[@]} host(s)."
+  for host in "${hosts[@]}"; do
+    authorize_one "${host}" "${line}" || failed=$((failed + 1))
+  done
+
+  if [ "${failed}" -gt 0 ]; then
+    err "${failed} host(s) failed."
+    exit 1
   fi
 }
 
@@ -158,24 +334,32 @@ Usage:
   $(basename "${0}") <command>
 
 Commands:
-  setup     Configure rbw (email, server, pinentry, lock timeout)
-  pull      Write ~/.ssh/config from the vault
-  push      Store the current ~/.ssh/config in the vault
-  status    Show rbw, vault and ssh-agent state
-  help      Show this help
+  setup              Configure rbw (email, server, pinentry, lock timeout)
+  pull               Write ~/.ssh/config from the vault
+  push               Store the current ~/.ssh/config in the vault
+  authorize [host…]  Append the vault public key to each host's
+                     authorized_keys. Without arguments, every non-wildcard
+                     Host in ~/.ssh/config is used.
+  status             Show rbw, vault and ssh-agent state
+  help               Show this help
 
 Environment:
-  SSH_CONFIG_ITEM    Vault item name (default: dotfiles-ssh-config)
+  SSH_CONFIG_ITEM    Vault item holding the config (default: dotfiles-ssh-config)
+  SSH_KEY_ITEM       Vault item holding the key (default: SSH)
   RBW_LOCK_TIMEOUT   Seconds before the master password is required again
                      (default: 300)
 EOF
 }
 
-case "${1:-help}" in
-  setup )  setup ;;
-  pull )   pull ;;
-  push )   push ;;
-  status ) status ;;
+cmd="${1:-help}"
+shift || true
+
+case "${cmd}" in
+  setup )     setup ;;
+  pull )      pull ;;
+  push )      push ;;
+  authorize ) authorize "$@" ;;
+  status )    status ;;
   help | --help | -h ) help ;;
-  * ) err "Unknown command: ${1}"; help; exit 1 ;;
+  * ) err "Unknown command: ${cmd}"; help; exit 1 ;;
 esac

--- a/bin/secrets.sh
+++ b/bin/secrets.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Manage secrets that must not live in this (public) repository.
+#
+# SSH keys are stored in Bitwarden as "SSH key" items and served by rbw-agent,
+# so no private key is ever written to disk. The ssh config is stored as a
+# secure note because it carries hostnames and account names.
+set -euo pipefail
+
+SSH_CONFIG_ITEM="${SSH_CONFIG_ITEM:-dotfiles-ssh-config}"
+SSH_CONFIG_PATH="${HOME}/.ssh/config"
+LOCK_TIMEOUT="${RBW_LOCK_TIMEOUT:-300}"
+
+# shell-logger.sh is deliberately not used here: its err() returns 100, which
+# would abort the script under set -e before the message is acted on.
+info ()   { printf '\033[0;32m[INFO]\033[0m %s\n' "$*"; }
+notice () { printf '\033[0;34m[NOTICE]\033[0m %s\n' "$*"; }
+err ()    { printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2; }
+
+require_rbw () {
+  if ! command -v rbw >/dev/null 2>&1; then
+    err "rbw is not installed. Run 'make install' first."
+    exit 1
+  fi
+}
+
+require_configured () {
+  require_rbw
+  if ! rbw config show >/dev/null 2>&1; then
+    err "rbw is not configured yet. Run 'make secrets-setup' first."
+    exit 1
+  fi
+}
+
+default_pinentry () {
+  case "$(uname -s)" in
+    Darwin*) command -v pinentry-mac >/dev/null 2>&1 && { echo pinentry-mac; return; } ;;
+  esac
+  command -v pinentry >/dev/null 2>&1 && { echo pinentry; return; }
+  echo pinentry-curses
+}
+
+# rbw uses $XDG_RUNTIME_DIR when present and falls back to a temp dir keyed by
+# uid otherwise, so probe both.
+ssh_agent_socket () {
+  local tmp candidate
+  tmp="${TMPDIR:-/tmp}"
+  for candidate in \
+    "${XDG_RUNTIME_DIR:-}/rbw/ssh-agent-socket" \
+    "${tmp%/}/rbw-$(id -u)/ssh-agent-socket"; do
+    if [ -S "${candidate}" ]; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+setup () {
+  require_rbw
+
+  if ! rbw config show >/dev/null 2>&1; then
+    notice "Bitwarden email:"
+    read -r email
+    rbw config set email "${email}"
+
+    notice "Server URL (leave blank for bitwarden.com):"
+    read -r base_url
+    if [ -n "${base_url}" ]; then
+      rbw config set base_url "${base_url}"
+    fi
+  fi
+
+  rbw config set pinentry "$(default_pinentry)"
+  rbw config set lock_timeout "${LOCK_TIMEOUT}"
+
+  info "rbw configured. pinentry=$(default_pinentry) lock_timeout=${LOCK_TIMEOUT}s"
+  info "Run 'rbw login' once, then 'rbw unlock' to start the agent."
+}
+
+pull () {
+  require_configured
+
+  local tmp
+  tmp="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmp}'" EXIT
+
+  if ! rbw get "${SSH_CONFIG_ITEM}" --field notes > "${tmp}"; then
+    err "Could not read '${SSH_CONFIG_ITEM}' from the vault."
+    err "Store the config first with: $(basename "$0") push"
+    exit 1
+  fi
+
+  if [ ! -s "${tmp}" ]; then
+    err "'${SSH_CONFIG_ITEM}' is empty. Refusing to overwrite ${SSH_CONFIG_PATH}."
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "${SSH_CONFIG_PATH}")"
+  install -m 600 "${tmp}" "${SSH_CONFIG_PATH}"
+  info "Wrote ${SSH_CONFIG_PATH} from '${SSH_CONFIG_ITEM}'."
+}
+
+push () {
+  require_configured
+
+  if [ ! -f "${SSH_CONFIG_PATH}" ]; then
+    err "${SSH_CONFIG_PATH} does not exist."
+    exit 1
+  fi
+
+  # rbw add/edit opens $EDITOR on a temp file and treats the first line as the
+  # password, so prepend a blank line to keep the config intact in the notes.
+  local editor tmp
+  editor="$(mktemp)"
+  tmp="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '${editor}' '${tmp}'" EXIT
+
+  { echo; cat "${SSH_CONFIG_PATH}"; } > "${tmp}"
+
+  cat > "${editor}" <<EOF
+#!/bin/sh
+cat "${tmp}" > "\$1"
+EOF
+  chmod +x "${editor}"
+
+  if rbw get "${SSH_CONFIG_ITEM}" >/dev/null 2>&1; then
+    EDITOR="${editor}" VISUAL="${editor}" rbw edit "${SSH_CONFIG_ITEM}"
+    info "Updated '${SSH_CONFIG_ITEM}' in the vault."
+  else
+    EDITOR="${editor}" VISUAL="${editor}" rbw add "${SSH_CONFIG_ITEM}"
+    info "Created '${SSH_CONFIG_ITEM}' in the vault."
+  fi
+}
+
+status () {
+  require_configured
+
+  echo "rbw:        $(rbw --version)"
+  echo "pinentry:   $(default_pinentry)"
+  echo "vault:      $(rbw unlocked >/dev/null 2>&1 && echo unlocked || echo locked)"
+
+  local sock
+  if sock="$(ssh_agent_socket)"; then
+    echo "ssh agent:  ${sock}"
+    SSH_AUTH_SOCK="${sock}" ssh-add -l 2>&1 | sed 's/^/            /'
+  else
+    echo "ssh agent:  not running (run 'rbw unlock')"
+  fi
+}
+
+help () {
+  cat <<EOF
+$(basename "${0}") manages secrets kept out of this repository.
+
+Usage:
+  $(basename "${0}") <command>
+
+Commands:
+  setup     Configure rbw (email, server, pinentry, lock timeout)
+  pull      Write ~/.ssh/config from the vault
+  push      Store the current ~/.ssh/config in the vault
+  status    Show rbw, vault and ssh-agent state
+  help      Show this help
+
+Environment:
+  SSH_CONFIG_ITEM    Vault item name (default: dotfiles-ssh-config)
+  RBW_LOCK_TIMEOUT   Seconds before the master password is required again
+                     (default: 300)
+EOF
+}
+
+case "${1:-help}" in
+  setup )  setup ;;
+  pull )   pull ;;
+  push )   push ;;
+  status ) status ;;
+  help | --help | -h ) help ;;
+  * ) err "Unknown command: ${1}"; help; exit 1 ;;
+esac

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -14,57 +14,70 @@ is required. It is packaged for both macOS (Homebrew) and Arch (`extra/rbw`).
 ## First run
 
 ```
-$ make install          # installs rbw and pinentry
+$ make install          # installs rbw, bw and pinentry
 $ make secrets-setup    # asks for the vault email and server URL
 $ rbw login
 $ rbw unlock            # starts rbw-agent, which is also the SSH agent
 $ make secrets          # writes ~/.ssh/config
 ```
 
-`make secrets-setup` sets `pinentry-mac` on macOS and `pinentry` elsewhere, and
-a `lock_timeout` of 300 seconds. Shorten it to be asked for the master password
-more often:
-
-```
-$ RBW_LOCK_TIMEOUT=60 make secrets-setup
-```
-
 ## Registering an SSH key
 
-Create the key **inside Bitwarden** (Web vault or desktop: new item -> SSH key ->
-generate). The private key is then never on any disk to begin with.
+Create the key **inside Bitwarden** (web vault: new item -> SSH key -> generate).
+The private key is then never on any disk to begin with. Bitwarden only
+generates ED25519 keys.
 
 ```
 $ rbw sync
-$ rbw unlock
-$ ssh-add -l             # the key should be listed
+$ ssh-add -l                                    # the key should be listed
+$ bash bin/secrets.sh authorize                 # append it to every host in the config
+$ bash bin/secrets.sh authorize <host>...       # or just these hosts
 ```
 
-To import an existing key instead, paste it into a new `SSH key` item and remove
-the local copy afterwards.
+`authorize` matches on the key body, ignoring the trailing comment, so it is
+safe to re-run. It verifies each host with a fresh connection afterwards —
+reusing a live ControlMaster would report success even when the key was never
+accepted. GitHub and similar hosts are skipped; register there through the web
+UI with `rbw get 'SSH' --field public_key`.
 
 ## Storing the ssh config
 
 ```
-$ make secrets-push      # ~/.ssh/config -> vault
 $ make secrets           # vault -> ~/.ssh/config
+$ make secrets-push      # ~/.ssh/config -> vault
 ```
 
-`push` prepends a blank line because `rbw add` treats the first line of the
-buffer as the password; the config itself lives in the note body.
+**`push` needs the official `bw` CLI**, which keeps credentials separately from
+rbw: the vault can be unlocked in rbw while `bw` is not even logged in. Run
+`bw login <email>` once from a normal terminal if that happens.
+
+rbw cannot write items non-interactively — `rbw add` waits on `$EDITOR` and
+never returns without a tty — so writes go through `bw` and its JSON interface.
+Reads stay on rbw. `push` reads the item back afterwards to prove the write
+landed; an earlier version reported success while storing nothing.
 
 ## How the shell picks up the agent
 
 `.zshrc.lazy` exports `SSH_AUTH_SOCK` when the rbw socket exists, probing both
-`$XDG_RUNTIME_DIR/rbw/` and the temp-dir fallback used on macOS. While the agent
-is not running the system agent stays in place, so nothing breaks.
+`$XDG_RUNTIME_DIR/rbw/` and the temp-dir fallback used on macOS. It also links
+the socket to `~/.local/share/ssh/rbw-agent.sock`, a stable path for tools that
+do not read the shell config — `~/.claude/settings.json` points `SSH_AUTH_SOCK`
+there so Claude Code can reach the agent.
+
+`ssh`, `scp` and `sftp` are wrapped: a locked vault leaves the agent with no
+keys and ssh only reports `Permission denied (publickey)`, so exit code 255
+triggers `rbw unlock` and one retry. Other exit codes, including a remote
+command's own status, pass through untouched.
 
 ## YubiKey
 
-`Host *` still sets `PKCS11Provider`, so a YubiKey keeps working independently
-of the agent: OpenSSH tries the PKCS#11 token and the agent both. Keep the
-YubiKey as the primary factor and treat the vault as the fallback for machines
-without it.
+`PKCS11Provider` now sits behind a `Match exec` that probes for a plugged-in
+YubiKey, because OpenSC otherwise prompts for a PIN on every connection. The
+probe costs about 5ms. The condition is macOS-only (`ioreg`); Linux needs its
+own rule if a YubiKey is used there.
+
+Keep the YubiKey as the fallback: it is the only way into the hosts if the
+vault becomes unavailable, and `mine-313.com` hosts the vault itself.
 
 ## Checking state
 
@@ -72,6 +85,7 @@ without it.
 $ bash bin/secrets.sh status
 rbw:        rbw 1.15.0
 pinentry:   pinentry-mac
-vault:      locked
-ssh agent:  not running (run 'rbw unlock')
+vault:      unlocked
+ssh agent:  /var/folders/.../rbw-501/ssh-agent-socket
+            256 SHA256:... (ED25519)
 ```

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,77 @@
+Secrets
+===
+
+This repository is public, so hostnames, account names and keys are kept in
+Bitwarden instead. [rbw](https://github.com/doy/rbw) reads them and doubles as
+an SSH agent, so **no private key is ever written to disk** and no desktop app
+is required. It is packaged for both macOS (Homebrew) and Arch (`extra/rbw`).
+
+| What | Where | How it is used |
+| --- | --- | --- |
+| SSH private/public keys | Bitwarden `SSH key` items | Served by `rbw-agent` over `$SSH_AUTH_SOCK` |
+| `~/.ssh/config` | Bitwarden secure note `dotfiles-ssh-config` | `make secrets` writes it into place |
+
+## First run
+
+```
+$ make install          # installs rbw and pinentry
+$ make secrets-setup    # asks for the vault email and server URL
+$ rbw login
+$ rbw unlock            # starts rbw-agent, which is also the SSH agent
+$ make secrets          # writes ~/.ssh/config
+```
+
+`make secrets-setup` sets `pinentry-mac` on macOS and `pinentry` elsewhere, and
+a `lock_timeout` of 300 seconds. Shorten it to be asked for the master password
+more often:
+
+```
+$ RBW_LOCK_TIMEOUT=60 make secrets-setup
+```
+
+## Registering an SSH key
+
+Create the key **inside Bitwarden** (Web vault or desktop: new item -> SSH key ->
+generate). The private key is then never on any disk to begin with.
+
+```
+$ rbw sync
+$ rbw unlock
+$ ssh-add -l             # the key should be listed
+```
+
+To import an existing key instead, paste it into a new `SSH key` item and remove
+the local copy afterwards.
+
+## Storing the ssh config
+
+```
+$ make secrets-push      # ~/.ssh/config -> vault
+$ make secrets           # vault -> ~/.ssh/config
+```
+
+`push` prepends a blank line because `rbw add` treats the first line of the
+buffer as the password; the config itself lives in the note body.
+
+## How the shell picks up the agent
+
+`.zshrc.lazy` exports `SSH_AUTH_SOCK` when the rbw socket exists, probing both
+`$XDG_RUNTIME_DIR/rbw/` and the temp-dir fallback used on macOS. While the agent
+is not running the system agent stays in place, so nothing breaks.
+
+## YubiKey
+
+`Host *` still sets `PKCS11Provider`, so a YubiKey keeps working independently
+of the agent: OpenSSH tries the PKCS#11 token and the agent both. Keep the
+YubiKey as the primary factor and treat the vault as the fallback for machines
+without it.
+
+## Checking state
+
+```
+$ bash bin/secrets.sh status
+rbw:        rbw 1.15.0
+pinentry:   pinentry-mac
+vault:      locked
+ssh agent:  not running (run 'rbw unlock')
+```

--- a/home/.zshrc.lazy
+++ b/home/.zshrc.lazy
@@ -111,6 +111,23 @@ fi
 # Bound last: do_enter hands off to zeno itself
 bindkey '^m' do_enter
 
+# ----------------- ssh -----------------
+
+# rbw-agent serves SSH keys straight from the Bitwarden vault, so no private
+# key is written to disk. Start it with `rbw unlock`; falls back to the system
+# agent while it is not running.
+if (( ${+commands[rbw]} )); then
+    for _rbw_sock in \
+        "${XDG_RUNTIME_DIR:-}/rbw/ssh-agent-socket" \
+        "${${TMPDIR:-/tmp}%/}/rbw-${UID}/ssh-agent-socket"; do
+        if [[ -S "$_rbw_sock" ]]; then
+            export SSH_AUTH_SOCK="$_rbw_sock"
+            break
+        fi
+    done
+    unset _rbw_sock
+fi
+
 # ----------------- Rust -----------------
 
 (( ${+commands[sccache]} )) && export RUSTC_WRAPPER=sccache

--- a/home/.zshrc.lazy
+++ b/home/.zshrc.lazy
@@ -122,10 +122,32 @@ if (( ${+commands[rbw]} )); then
         "${${TMPDIR:-/tmp}%/}/rbw-${UID}/ssh-agent-socket"; do
         if [[ -S "$_rbw_sock" ]]; then
             export SSH_AUTH_SOCK="$_rbw_sock"
+            # Stable path for tools that do not source this file (e.g. Claude Code),
+            # since the real socket lives under a per-session TMPDIR on macOS.
+            mkdir -p "$HOME/.local/share/ssh"
+            ln -sfn "$_rbw_sock" "$HOME/.local/share/ssh/rbw-agent.sock"
             break
         fi
     done
     unset _rbw_sock
+
+    # A locked vault leaves the agent with no keys, and ssh only reports
+    # "Permission denied (publickey)". Unlock and retry instead of failing.
+    # 255 is ssh's own error code, as opposed to a remote command's status.
+    _rbw_retry() {
+        local cmd="$1"; shift
+        command "$cmd" "$@"
+        local rc=$?
+        (( rc == 255 )) || return $rc
+        rbw unlocked >/dev/null 2>&1 && return $rc
+        print -u2 -P "%F{yellow}[$cmd] vault is locked; unlocking and retrying%f"
+        rbw unlock || return $rc
+        command "$cmd" "$@"
+    }
+
+    ssh()  { _rbw_retry ssh "$@" }
+    scp()  { _rbw_retry scp "$@" }
+    sftp() { _rbw_retry sftp "$@" }
 fi
 
 # ----------------- Rust -----------------

--- a/packages/arch-repo.txt
+++ b/packages/arch-repo.txt
@@ -74,6 +74,7 @@ openrgb
 opensc
 openssh
 pavucontrol
+pinentry
 pipewire
 pipewire-alsa
 pipewire-pulse
@@ -94,6 +95,7 @@ python-scipy
 python-typer
 qemu-system-riscv
 qt5-wayland
+rbw
 ripgrep
 riscv64-elf-gcc
 sbt


### PR DESCRIPTION
## Summary

This repository is public, so the ssh config and keys cannot live in it. SSH keys now sit in Bitwarden as `SSH key` items and are served by `rbw-agent`, which doubles as an SSH agent — **no private key is written to disk**, and no desktop app is involved. rbw needs no GUI and is packaged for both macOS (`brew`) and Arch (`extra/rbw`), unlike Bitwarden's own SSH agent which is desktop-only.

- `bin/secrets.sh`: `setup` / `pull` / `push` / `authorize` / `status`.
- `make secrets`, `secrets-push`, `secrets-setup`.
- `.zshrc.lazy` exports `SSH_AUTH_SOCK` when the rbw socket exists, probing both `$XDG_RUNTIME_DIR` and the temp-dir fallback rbw uses on macOS, and links it to a stable path for tools that do not read the shell config.
- `ssh` / `scp` / `sftp` retry once through `rbw unlock` on exit code 255 — a locked vault otherwise fails with a bare `Permission denied (publickey)`.
- Brewfile gains `rbw`, `pinentry-mac` and `shellcheck`; the Arch list gains `rbw` and `pinentry`.
- `docs/secrets.md` covers key registration, the bw/rbw split and the YubiKey relationship.

### Problems found while putting this into use

- **`push` silently stored nothing.** It drove `rbw add`/`rbw edit` through a fake `$EDITOR`, but rbw waits on the editor and never returns without a tty, so the item stayed empty while the script reported success. Writes now go through the official `bw` CLI and its JSON interface, and the item is read back afterwards to prove the write landed. Reads stay on rbw.
- `bw` keeps credentials separately from rbw, so an `unauthenticated` state is now reported with the `bw login` hint instead of failing obscurely.
- `bw unlock --raw` writes its prompt to stdout and breaks under command substitution (`ERR_USE_AFTER_CLOSE`), so the password is read directly and passed via `--passwordenv`. `/dev/tty` is not usable in every host terminal.
- `authorize` matched the whole line including the comment, so a key installed by hand was appended a second time. It now matches on the key body only.
- `authorize` did not export `SSH_AUTH_SOCK`, so its verification step could never authenticate.
- `pull` now strips the trailing newline rbw appends, so the config no longer grows a blank line on each round trip.
- `pinentry-curses` is preferred over `pinentry-mac`: the agent is often driven over ssh, where a GUI prompt cannot be answered.

## Test plan

- `make secrets-push` then `make secrets`: round trip is byte-identical (706 bytes both ways).
- `bash bin/secrets.sh authorize <host>` installs the key, is idempotent on re-run, and verifies with a connection that has ControlMaster disabled.
- `ssh` wrapper: normal exit passes through, a remote `exit 42` still returns 42, exit 255 with a locked vault triggers `rbw unlock` and a retry, exit 255 with an unlocked vault does not.
- Six hosts now authenticate with the vault key alone, verified with `-o ControlMaster=no -o ControlPath=none` so a live master connection cannot mask a failure.
- `shellcheck` passes on `bin/secrets.sh` (added to CI).

## Breaking changes

- `home/.ssh/config` is no longer tracked; a fresh machine gets it with `make secrets`.
- `ControlMaster` / `ControlPath` / `ControlPersist` were dropped from the ssh config.
- `PKCS11Provider` now sits behind a `Match exec` that probes for a plugged-in YubiKey, because OpenSC otherwise prompts for a PIN on every connection. The condition is macOS-only; Linux needs its own rule.
- Requires `rbw`, `bw` and a terminal `pinentry`.