### PR TITLE
[fix] stop the deno installer from editing .zshrc

### DIFF
--- a/bin/arch_install.sh
+++ b/bin/arch_install.sh
@@ -38,7 +38,10 @@ fi
 # with it the Enter key). The upstream build bundles its own SQLite.
 if [ ! -x "${HOME}/.deno/bin/deno" ]; then
     echo "installing the official deno build..."
-    DENO_INSTALL="${HOME}/.deno" sh -c "$(curl -fsSL https://deno.land/install.sh)" -- -y
+    # --no-modify-path: the installer otherwise appends a `. ~/.deno/env` line
+    # to .zshrc, which is a tracked file in this repository. PATH is handled
+    # in .zshrc.lazy instead.
+    DENO_INSTALL="${HOME}/.deno" sh -c "$(curl -fsSL https://deno.land/install.sh)" -- -y --no-modify-path
 fi
 
 if pacman -Qq deno >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

`arch_install.sh` runs deno's official installer, which appends

```
. "$HOME/.deno/env"
```

to `.zshrc`. That file is tracked in this repository, so the install left the working tree dirty and the machine's next `git pull` aborted with *"Please commit your changes or stash them before you merge"*. This happened on polaris today.

Pass `--no-modify-path`; `.zshrc.lazy` already puts `~/.deno/bin` on PATH for Linux.

## Test plan

- `curl -fsSL https://deno.land/install.sh | grep -- --no-modify-path` confirms the flag exists.
- `shellcheck bin/arch_install.sh` passes.
- polaris was restored with `git checkout -- home/.zshrc` and now pulls cleanly.

## Breaking changes

None.